### PR TITLE
Use --no-renames consistently

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,7 +152,9 @@ async function getSize({baseRef, exec, excludes}) {
 		[
 			'diff',
 			`origin/${baseRef}`,
-			'HEAD', '--numstat',
+			'HEAD',
+			'--no-renames',
+			'--numstat',
 			'--ignore-space-change',
 			'--',
 			'.',


### PR DESCRIPTION
Always pass `--no-renames` to `git diff`. It was already passed into the gathering of excludes, but was missing when calculating the size of the change.