### PR TITLE
Document error behaviour for missing git branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         id: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          # fetch-depth: 0
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
         id: checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          fetch-depth: 0
+          # fetch-depth: 0
           persist-credentials: false
 
       - name: Size

--- a/README.md
+++ b/README.md
@@ -246,3 +246,20 @@ Example output:
 ```text
 PR #26
 ```
+
+## Troubleshooting
+
+### `git diff` failed
+
+If `actions/checkout` was not configured with `fetch-depth: 0`, the following
+error will be output. A branch other than `main` may be output depending on your
+repository settings.
+
+```
+fatal: ambiguous argument 'origin/main': unknown revision or path not in the working tree.
+```
+
+To correct this, set `fetch-depth: 0` for the `actions/checkout` action to fetch
+the history for all branches as shown in [Usage](#usage). This means `git diff`
+can compare the pull request's branch to its target branch and so calculate the
+size of the change.

--- a/index.js
+++ b/index.js
@@ -22,10 +22,6 @@ module.exports = async ({context, core, exec, github}) => {
 		await assignLabel({context, github, label})
 	} catch (error) {
 		if (error instanceof Error) {
-			if (error.message.includes('unknown revision or path not in the working tree')) {
-				core.error('Please confirm that actions/checkout is configured with fetch-depth: 0')
-			}
-
 			core.setFailed(error.message)
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ module.exports = async ({context, core, exec, github}) => {
 		await assignLabel({context, github, label})
 	} catch (error) {
 		if (error instanceof Error) {
+			if (error.message.includes('unknown revision or path not in the working tree')) {
+				core.error('Please confirm that actions/checkout is configured with fetch-depth: 0')
+			}
+
 			core.setFailed(error.message)
 		}
 	}

--- a/index.js
+++ b/index.js
@@ -27,6 +27,9 @@ module.exports = async ({context, core, exec, github}) => {
 	}
 }
 
+/**
+ * Collect the configuration for all labels.
+ */
 function labels() {
 	return [
 		{
@@ -68,6 +71,9 @@ function labels() {
 	]
 }
 
+/**
+ * Create size labels so they can be assigned to pull requests.
+ */
 async function createLabels({context, github}) {
 	const resp = await github.rest.issues.listLabelsForRepo(context.repo)
 	const have = new Set(resp.data.map(l => l.name))
@@ -86,10 +92,16 @@ async function createLabels({context, github}) {
 	}
 }
 
+/**
+ * Map the calculated size to the corresponding label.
+ */
 function selectLabel({size}) {
 	return labels().find(l => l.threshold > size)
 }
 
+/**
+ * Assign the chosen label to the pull request.
+ */
 async function assignLabel({context, github, label}) {
 	const resp = await github.rest.issues.listLabelsOnIssue({
 		...context.repo,
@@ -122,22 +134,25 @@ async function assignLabel({context, github, label}) {
 	}
 }
 
+/**
+ * Gather the files that should be excluded from the size calculation.
+ */
 async function gatherExcludes({baseRef, exec}) {
-	const s1 = await execute(
+	const o1 = await exec.getExecOutput(
 		exec,
 		'git',
 		['diff', `origin/${baseRef}`, 'HEAD', '--name-only', '--no-renames']
 	)
-	const files = s1
+	const files = o1.stdout
 		.split(/\r?\n/)
 		.filter(n => n.length > 0)
 
-	const s2 = await execute(
+	const o2 = await exec.getExecOutput(
 		exec,
 		'git',
 		['check-attr', 'linguist-generated', 'linguist-vendored', '--', ...files]
 	)
-	const excludes = s2
+	const excludes = o2.stdout
 		.split(/\r?\n/)
 		.filter(a => a.endsWith(': set'))
 		.map(a => a.split(':')[0])
@@ -145,9 +160,11 @@ async function gatherExcludes({baseRef, exec}) {
 	return [...new Set(excludes)]
 }
 
+/**
+ * Calculate the size of the change, returning the size and the files used in the calculation.
+ */
 async function getSize({baseRef, exec, excludes}) {
-	const output = await execute(
-		exec,
+	const output = await exec.getExecOutput(
 		'git',
 		[
 			'diff',
@@ -161,7 +178,7 @@ async function getSize({baseRef, exec, excludes}) {
 			...excludes.map(e => `:^${e}`)
 		],
 	);
-	const data = output
+	const data = output.stdout
 		.split(/\r?\n/)
 		.filter(c => c.length > 0)
 		.map(c => {
@@ -178,18 +195,4 @@ async function getSize({baseRef, exec, excludes}) {
 		size: data.reduce((t, d) => t + d.added + d.removed, 0),
 		includes: data.map(d => d.name)
 	}
-}
-
-async function execute(exec, cmd, args) {
-	let output = '';
-	const options = {
-		listeners: {
-			stdout: (data) => {
-				output += data.toString();
-			},
-		},
-	};
-
-	await exec.exec(cmd, args, options);
-	return output
 }

--- a/index.js
+++ b/index.js
@@ -139,7 +139,6 @@ async function assignLabel({context, github, label}) {
  */
 async function gatherExcludes({baseRef, exec}) {
 	const o1 = await exec.getExecOutput(
-		exec,
 		'git',
 		['diff', `origin/${baseRef}`, 'HEAD', '--name-only', '--no-renames']
 	)
@@ -148,7 +147,6 @@ async function gatherExcludes({baseRef, exec}) {
 		.filter(n => n.length > 0)
 
 	const o2 = await exec.getExecOutput(
-		exec,
 		'git',
 		['check-attr', 'linguist-generated', 'linguist-vendored', '--', ...files]
 	)


### PR DESCRIPTION
- Document error behaviour when `actions/checkout` is missing the required `fetch-depth: 0` input.
- Use built-in function for getting stdout from executing commands.